### PR TITLE
Don't include optional blob properties in generated pipeline script

### DIFF
--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/config.jelly
@@ -38,9 +38,9 @@
 
     <f:section title="${%blobPropertiesMetadata_title}">
         <f:advanced title="${%edit_title}">
-            <f:property field="blobProperties">
+            <f:optionalProperty title="${%blobPropertiesMetadata_title}" field="blobProperties">
                 <st:include page="config.jelly" class="${descriptor.clazz}"/>
-            </f:property>
+            </f:optionalProperty>
 
             <f:entry title="${%blobMetadata_title}">
                 <f:repeatableProperty field="metadata">


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/azure-storage-plugin/issues/212

Pipeline syntax will no longer generate an empty `[]` which doesn't work.
You need to either omit it or include at least one field.

