### PR TITLE
Remove unused md5 field + optimise file upload

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlob.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlob.java
@@ -12,31 +12,18 @@ public class AzureBlob implements Serializable {
 
     private final String blobName;
     private final String blobURL;
-    private final String md5;
     private final long byteSize;
     private final String storageType;
     private final String credentialsId;
 
-    @Deprecated
     public AzureBlob(
             String blobName,
             String blobURL,
-            String md5,
-            long byteSize,
-            String storageType) {
-        this(blobName, blobURL, md5, byteSize, storageType, null);
-    }
-
-    public AzureBlob(
-            String blobName,
-            String blobURL,
-            String md5,
             long byteSize,
             String storageType,
             String credentialsId) {
         this.blobName = blobName;
         this.blobURL = blobURL;
-        this.md5 = md5;
         this.byteSize = byteSize;
         this.storageType = storageType;
         this.credentialsId = credentialsId;
@@ -54,11 +41,6 @@ public class AzureBlob implements Serializable {
     @Exported
     public String getBlobURL() {
         return blobURL;
-    }
-
-    @Exported
-    public String getMd5() {
-        return md5;
     }
 
     @Exported


### PR DESCRIPTION
An azure-sdk-for-java maintainer recommended switching to the non response API as a better way of handling https://github.com/jenkinsci/azure-storage-plugin/issues/210.

A consequence of that is that the response is not available but the only place we use that is exposing it in the API, I can't see any actual usages of it, please raise an issue if you actually need it but this value has been inaccurate for a long time as it 
was the 'block' md5 and not the whole file.

see
https://github.com/Azure/azure-sdk-for-java/issues/26867#issuecomment-1031941870