### PR TITLE
Fix BlockBlobClient cast error downloading from job

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadService.java
@@ -15,7 +15,7 @@
 
 package com.microsoftopentechnologies.windowsazurestorage.service;
 
-import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.specialized.BlobClientBase;
 import com.azure.storage.file.share.ShareFileClient;
 import com.microsoftopentechnologies.windowsazurestorage.Messages;
 import com.microsoftopentechnologies.windowsazurestorage.exceptions.WAStorageException;
@@ -57,8 +57,8 @@ public abstract class DownloadService extends StoragePluginService<DownloadServi
         @Override
         public void run() {
             try {
-                if (downloadItem instanceof BlobClient) {
-                    downloadBlob((BlobClient) downloadItem);
+                if (downloadItem instanceof BlobClientBase) {
+                    downloadBlob((BlobClientBase) downloadItem);
                 } else {
                     downloadSingleFile((ShareFileClient) downloadItem);
                 }
@@ -113,7 +113,7 @@ public abstract class DownloadService extends StoragePluginService<DownloadServi
         }
     }
 
-    protected void downloadBlob(BlobClient blob) throws WAStorageException {
+    protected void downloadBlob(BlobClientBase blob) throws WAStorageException {
         try {
             if (getServiceData().isVerbose()) {
                 println("Downloading file:" + blob.getBlobUrl());


### PR DESCRIPTION
I make extensive use of "Download artifact from build -> Upstream build that triggered this job". As of today, this throws:

```
com.azure.storage.blob.specialized.BlockBlobClient cannot be cast to com.azure.storage.file.share.ShareFileClient
```

This doesn't work with the current mix of Azure plugin dependencies on an up-to-date Jenkins install. The core issue is when the download items are enumerated, they are of type `BlockBlobClient` not `BlobClient` - the `instanceof` check therefore falls through into the `ShareFileClient` case, and that's not a valid cast.

Instead, check for the parent type of both `BlobClient` and `BlockBlobClient`, `BlobClientBase`. This is valid for the current case _and_ the old case, so should be safe for various combinations of dependency versions.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue