### PR TITLE
Allow developer control of parallel testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(useContainerAgent: true, configurations: [
+buildPlugin(useContainerAgent: true, forkCount: '1C', configurations: [
   [ platform: 'linux', jdk: '11' ],
   [ platform: 'linux', jdk: '17' ]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -175,15 +175,6 @@
                     <excludes>com/microsoftopentechnologies/windowsazurestorage/Messages.java</excludes>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>1C</forkCount>
-                    <parallel>all</parallel>
-                    <useUnlimitedThreads>true</useUnlimitedThreads>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Allow developer control of parallel testing

Move the definition of parallel testing from the Maven pom file into the Jenkinsfile so that ci.jenkins.io continues to run the tests with one process per available core, while developers are allowed to configure the amount of parallel testing based on the configuration and use of their computer.

Developers can adjust parallel execution by passing a command line argument to Maven like this:

```bash
  mvn clean -DforkCount=1C verify
```

Developers can define a Maven profile that sets the forkCount in their
~/.m2/settings.xml like this:

```xml
  <profile>
    <id>faster</id>
    <activation>
      <activeByDefault>true</activeByDefault>
    </activation>
    <properties>
      <forkCount>.45C</forkCount>
    </properties>
  </profile>
```

With that entry in the settings.xml file, then 0.45C will be used for:

```bash
  mvn clean verify
```

### Testing done

Tests pass with `-DforkCount=1C` on my Linux computer with Java 11.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
