### PR TITLE
Remove mandatory install of blue ocean plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean-rest</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBlueArtifact.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBlueArtifact.java
@@ -13,8 +13,14 @@ import io.jenkins.blueocean.rest.model.BlueArtifact;
 
 @Extension(optional = true)
 public final class AzureStorageBlueArtifact extends BlueArtifact {
-    private final AzureBlobAction action;
-    private final AzureBlob artifact;
+    private AzureBlobAction action;
+    private AzureBlob artifact;
+
+    public AzureStorageBlueArtifact() {
+        super(null);
+        this.action = null;
+        this.artifact = null;
+    }
 
     public AzureStorageBlueArtifact(AzureBlobAction action, AzureBlob artifact, Link parent) {
         super(parent);

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBlueArtifact.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBlueArtifact.java
@@ -11,6 +11,7 @@ import io.jenkins.blueocean.rest.factory.BlueArtifactFactory;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueArtifact;
 
+@Extension(optional = true)
 public final class AzureStorageBlueArtifact extends BlueArtifact {
     private final AzureBlobAction action;
     private final AzureBlob artifact;


### PR DESCRIPTION
Fixes #278 

As a user of the azure-storage plugin who doesn't use BO at all, it's frustrating that I need this dependency installed.
Would you strongly object to removing the BO integration all together @timja?

It was added in 2018 when BO was alive, but 6 years later, it's declared abandoned and EOL. I see no real reason why we should keep up an integration for an end-of-life plugin.