### PR TITLE
Fix Azure SDK 292 dependency convergence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>azure-sdk</artifactId>
-            <version>290.vf82a_b_3911a_c0</version>
+            <version>292.v2db_0b_b_b_50d35</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-core-http-netty</artifactId>
+                <version>1.16.6</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Repairs the dependency convergence failure in #428 at source head `31d8a95794d7e2aa49d7eb3d68707662328f7b68`.

Azure SDK API 292 brings `azure-core-http-netty` 1.16.5 through `azure-identity`, while Blob Storage, File Share, Storage Common, and Key Vault require 1.16.6. Maven selects the nearer 1.16.5 path and the Jenkins parent POM's `RequireUpperBoundDeps` rule rejects that graph.

Manage the shared artifact at the required upper bound, 1.16.6. This keeps the SDK upgrade intact and changes no production code. The Jenkins `BanObsoleteDependencyOverrides` rule also passed, so the override remains removable when a future SDK release no longer needs it.

### Testing done

- Reproduced the source failure on JDK 21 with `mvn --batch-mode --show-version --errors --no-transfer-progress validate`.
- Verified the complete dependency tree, then confirmed all five paths resolve to `azure-core-http-netty:1.16.6` with `mvn --batch-mode --show-version --errors --no-transfer-progress dependency:tree -Dincludes=com.azure:azure-core-http-netty -Dverbose`.
- JDK 21: `mvn --batch-mode --show-version --errors --no-transfer-progress -Penable-jacoco clean verify` — 74 tests, 0 failures/errors, 3 existing skips; Checkstyle, SpotBugs, JaCoCo report generation, enforcer rules, and HPI assembly passed.
- JDK 17: the same clean verification passed with the same 74-test result and package/static-analysis gates.

Both clean verification runs used Maven 3.9.16 on macOS x86_64. The repository CI remains the Windows-specific proof.

### AI assistance

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):

- `jaipilot-maintainer-intent`
- `jaipilot-fast-execution`
- `jaipilot-review-diff`
- Execution profile: gpt-5.6-sol · xhigh · fast

### Submitter checklist

- [x] Opened from a topic branch.
- [x] Used a changelog-ready title.
- [x] Described the change and linked the source pull request.
- [x] Ran tests that exercise dependency resolution, compilation, tests, analysis, and HPI packaging.
