### PR TITLE
Update Jenkins baseline to 2.555.3 and require Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,6 @@
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(useContainerAgent: true, forkCount: '1C', configurations: [
-  [platform: 'linux', jdk: 21],
-  [platform: 'windows', jdk: 17],
+  [platform: 'linux', jdk: 25],
+  [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/azure-storage-plugin</gitHubRepo>
-        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.baseline>2.555</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
         <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>5054.v620b_5d2b_d5e6</version>
+                <version>6931.vea_a_b_c6fd017d</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -42,6 +42,16 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- tika-core offers jakarta APIs at a shallower depth than the newer ones from
+             azure-sdk; declare them so the newer versions resolve -->
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jakarta-activation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jakarta-xml-bind-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>azure-sdk</artifactId>
@@ -101,6 +111,8 @@
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean-rest</artifactId>
+            <!-- no longer managed by the plugin BOM -->
+            <version>1.27.26</version>
             <optional>true</optional>
         </dependency>
 


### PR DESCRIPTION
Update the Jenkins baseline from 2.479.3 to 2.555.3, one of the [currently recommended versions](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions).

## What's changed

- `jenkins.baseline` 2.479 -> 2.555, and the plugin BOM to `bom-2.555.x`.
- Jenkins 2.555.1 and newer require Java 21, so the JDK 17 build had to move: `linux/21, windows/17` -> `linux/25, windows/21`, per the [Java support policy](https://www.jenkins.io/doc/book/platform-information/support-policy-java/).
- Declared `jakarta-activation-api` and `jakarta-xml-bind-api` to resolve a `requireUpperBoundDeps` failure caused by the old `tika-core` winning over `azure-sdk`'s newer Jakarta APIs on dependency depth.
- Pinned `blueocean-rest` explicitly — `bom-2.555.x` no longer manages it, so the versionless dependency stopped resolving.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk baseline update across the plugins I maintain. If anything here looks wrong, please comment on this PR.
